### PR TITLE
Change const to var in for...in loop

### DIFF
--- a/django_colortag/static/django_colortag.js
+++ b/django_colortag/static/django_colortag.js
@@ -39,7 +39,7 @@ function django_colortag_label(colortag, options_) {
   attrs['class'] = classes.join(' ');
   attrs['style'] = 'background-color: ' + colortag.color + ';';
 
-  for (const k in colortag['data-attrs']) {
+  for (var k in colortag['data-attrs']) {
     attrs['data-tag' + k] = colortag['data-attrs'][k];
   }
 


### PR DESCRIPTION
Turns out that
* IE11 does support const variables
* IE11 does support for...in loops
BUT
* IE11 does NOT support const variables as for...in loop variables