### PR TITLE
Django 1.11 template-based widget rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Installation and usage
 
 Requirements:
 
- * [Django](https://www.djangoproject.com/) 1.9+
+ * [Django](https://www.djangoproject.com/) 1.11+ (Django 1.9 and 1.10 are supported in versions 1.X of this project)
  * [django-html5-colorfield](https://github.com/knyghty/django-html5-colorfield) 1.0+
  * [js-jquery-toggle-django](https://github.com/Aalto-LeTech/js-jquery-toggle) for `jquery_toggle.js`
  * (recommended) [raphendyr-django-essentials](https://github.com/raphendyr/raphendyr-django-essentials) for app dependency management
@@ -18,7 +18,7 @@ Requirements:
 Add stuff to `requirements.txt`:
 
 ```
-git+https://github.com/Aalto-LeTech/django-colortag.git@1.2.0#egg=django-colortag==1.2.0
+git+https://github.com/Aalto-LeTech/django-colortag.git@2.0.0#egg=django-colortag==2.0.0
 ```
 
 Install them with `pip install --process-dependency-links -r requirements.txt`

--- a/django_colortag/fields.py
+++ b/django_colortag/fields.py
@@ -3,8 +3,18 @@ from django.forms import models
 from .widgets import ColortagSelectMultiple
 
 
+class ModelChoiceInstanceIterator(models.ModelChoiceIterator):
+    def choice(self, obj):
+        # Add the model instance to the iterated items.
+        (value, label) = super().choice(obj)
+        return (value, label, obj)
+
 class ColortagChoiceField(models.ModelMultipleChoiceField):
     widget = ColortagSelectMultiple
+    iterator = ModelChoiceInstanceIterator
+    # The iterator is used in the self.choices property, which is also set to
+    # widget.choices. This custom iterator includes the original model instance
+    # so that the widget may render instance-specific attributes in HTML.
 
     def label_from_instance(self, obj):
-        return obj
+        return obj.name

--- a/django_colortag/widgets.py
+++ b/django_colortag/widgets.py
@@ -1,4 +1,7 @@
+from itertools import chain
+
 from django.forms import widgets
+from django.utils.encoding import force_text
 
 
 def get_colortag_attrs(colortag, options):
@@ -31,23 +34,70 @@ def get_colortag_classes(colortag, options):
     return cls
 
 
-class CheckboxColortagInput(widgets.CheckboxChoiceInput):
-    def __init__(self, name, value, attrs, choice, index):
-        tag = choice[1]
-        super().__init__(name, value, attrs, choice, index)
-        self.choice_label = tag.name
-        options = {
-            'button': True,
-        }
-        attrs = self.attrs
-        attrs.update(get_colortag_attrs(tag, options))
-        attrs['data-class'] = ' '.join(get_colortag_classes(tag, options))
-
-
-class CheckboxColortagRenderer(widgets.CheckboxFieldRenderer):
-    choice_input_class = CheckboxColortagInput
-    outer_html = '<ul{id_attr} class="colortag-choice">{content}</ul>'
-
-
 class ColortagSelectMultiple(widgets.CheckboxSelectMultiple):
-    renderer = CheckboxColortagRenderer
+
+    option_inherits_attrs = False # option checkboxes need not inherit attributes from the list element
+
+    def __init__(self, attrs=None, choices=()):
+        super().__init__(attrs=attrs, choices=choices)
+        if 'class' in self.attrs:
+            self.attrs['class'] += ' colortag-choice'
+        else:
+            self.attrs['class'] = 'colortag-choice'
+
+    def optgroups(self, name, value, attrs=None):
+        """Return a list of optgroups for this widget."""
+        # Copied from https://github.com/django/django/blob/stable/1.11.x/django/forms/widgets.py#L570
+        # (Django 1.11 django.forms.widgets.ChoiceWidget method optgroups)
+        # and then slightly modified so that self.choices includes
+        # model instances in addition to the HTML input values and labels.
+        # Model instances in self.choices originate from the field ColortagChoiceField.
+        groups = []
+        has_selected = False
+
+        for index, (option_value, option_label, colortag_instance) in enumerate(chain(self.choices)):
+            if option_value is None:
+                option_value = ''
+
+            subgroup = []
+            if isinstance(option_label, (list, tuple)):
+                group_name = option_value
+                subindex = 0
+                choices = option_label
+            else:
+                group_name = None
+                subindex = None
+                choices = [(option_value, option_label)]
+            groups.append((group_name, subgroup, index))
+
+            for subvalue, sublabel in choices:
+                selected = (
+                    force_text(subvalue) in value and
+                    (has_selected is False or self.allow_multiple_selected)
+                )
+                if selected is True and has_selected is False:
+                    has_selected = True
+                subgroup.append(self.create_option(
+                    name, subvalue, sublabel, selected, index,
+                    subindex=subindex, attrs=attrs,
+                    colortag_instance=colortag_instance,
+                ))
+                if subindex is not None:
+                    subindex += 1
+        return groups
+
+    def create_option(self, name, value, label, selected, index, subindex=None, attrs=None,
+            colortag_instance=None):
+        # colortag_instance is a new parameter that is not used in the super class method.
+        # The overridden optgroups method uses this method.
+        option = super().create_option(name, value, label, selected, index, subindex=subindex, attrs=attrs)
+        if colortag_instance is None:
+            return option
+        # Add custom attributes to the option (one checkbox) that are based on
+        # the corresponding ColorTag instance.
+        opts = { 'button': True }
+        attrs = option['attrs']
+        attrs.update(get_colortag_attrs(colortag_instance, opts))
+        attrs['data-class'] = ' '.join(get_colortag_classes(colortag_instance, opts))
+        return option
+

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='django-colortag',
-    version='1.3.1',
+    version='2.0.0',
     description='Django tools for data tagging models',
     long_description=long_description,
     keywords='django models tagging',
@@ -42,7 +42,7 @@ setup(
         'Topic :: Software Development :: Build Tools',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Framework :: Django',
-        'Framework :: Django :: 1.9',
+        'Framework :: Django :: 1.11',
 
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
@@ -54,7 +54,7 @@ setup(
     include_package_data = True,
 
     install_requires=[
-        'Django >=1.9.7, <2',
+        'Django >=1.11.0, <3',
         'django-html5-colorfield >=1.0, <2',
         'js-jquery-toggle-django >=1.0.0, <2',
     ],


### PR DESCRIPTION
Use the new template-based widget rendering in Django 1.11 and remove dependencies on Django widget classes that were removed in Django 1.11.

Fix #4 