### PR TITLE
Add include-exclude-filters and support for three-state-buttons

### DIFF
--- a/django_colortag/fields.py
+++ b/django_colortag/fields.py
@@ -1,6 +1,10 @@
-from django.forms import models
+from django.forms import models, fields
 
-from .widgets import ColortagSelectMultiple
+from .widgets import (
+    ColortagSelectMultiple,
+    ColortagIEMultiWidget,
+    ColortagIEAndOrWidget
+)
 
 
 class ModelChoiceInstanceIterator(models.ModelChoiceIterator):
@@ -18,3 +22,46 @@ class ColortagChoiceField(models.ModelMultipleChoiceField):
 
     def label_from_instance(self, obj):
         return obj.name
+
+
+class ColortagIEField(models.ModelMultipleChoiceField):
+    widget = ColortagIEMultiWidget
+    iterator = ModelChoiceInstanceIterator
+
+    def set_queryset(self, queryset):
+        self.queryset = queryset
+        self.widget.set_subwidgets(queryset)
+
+    def clean(self, value):
+        includes = []
+        excludes = []
+        for v in value:
+            if v == None or len(v) < 2:
+                continue
+            elif v[0] == 'I':
+                includes.append(v[1:])
+            elif v[0] == 'E':
+                excludes.append(v[1:])
+        includes_qs = super().clean(includes)
+        excludes_qs = super().clean(excludes)
+        return (includes_qs, excludes_qs)
+
+
+class ColortagIEAndOrField(fields.MultiValueField):
+    widget = ColortagIEAndOrWidget
+
+    def __init__(self, queryset, *args, **kwargs):
+        kwargs.setdefault('require_all_fields', False)
+        subfields = (
+            fields.BooleanField(required=False),
+            ColortagIEField(queryset, required=False)
+        )
+        super().__init__(subfields, *args, **kwargs)
+
+    def set_queryset(self, queryset):
+        self.queryset = queryset
+        self.fields[1].queryset = queryset
+        self.widget.set_subwidgets(queryset)
+
+    def compress(self, data_list):
+        return data_list

--- a/django_colortag/filters.py
+++ b/django_colortag/filters.py
@@ -1,7 +1,47 @@
+from django.db.models import Q
+
 import django_filters
 
-from .fields import ColortagChoiceField
+from .fields import (
+    ColortagChoiceField,
+    ColortagIEField,
+    ColortagIEAndOrField
+)
 
 
 class ColortagChoiceFilter(django_filters.ModelMultipleChoiceFilter):
     field_class = ColortagChoiceField
+
+
+class ColortagIncludeExcludeFilter(django_filters.ModelMultipleChoiceFilter):
+    field_class = ColortagIEField
+
+    def filter(self, qs, values, conjoined=False):
+        includes, excludes = values
+        if not includes and not excludes:
+            return qs
+
+        if not conjoined:
+            q = Q()
+        for v in set(includes):
+            predicate = self.get_filter_predicate(v)
+            if conjoined:
+                qs = qs.filter(**predicate)
+            else:
+                q |= Q(**predicate)
+        if not conjoined:
+            qs = qs.filter(q)
+
+        for v in set(excludes):
+            predicate = self.get_filter_predicate(v)
+            qs = qs.exclude(**predicate)
+
+        return qs.distinct() if self.distinct else qs
+
+
+class ColortagIEAndOrFilter(ColortagIncludeExcludeFilter):
+    field_class = ColortagIEAndOrField
+
+    def filter(self, qs, values):
+        conjoined, inc_exc = values
+        return super().filter(qs, inc_exc, conjoined=conjoined)

--- a/django_colortag/locale/fi/LC_MESSAGES/django.po
+++ b/django_colortag/locale/fi/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-14 10:12+0300\n"
+"POT-Creation-Date: 2019-08-29 13:34+0300\n"
 "PO-Revision-Date: 2016-09-14 10:20+0200\n"
 "Last-Translator: Jaakko Kantojärvi <jaakko@n-1.fi>\n"
 "Language-Team: English <>\n"
@@ -17,21 +17,28 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Lokalize 2.0\n"
 
-#: django_colortag/models.py:17
+#: django_colortag_/models.py:23
 msgid "Display name for tag"
 msgstr "Tagin näyttönimi"
 
-#: django_colortag/models.py:18
+#: django_colortag_/models.py:24
 msgid "Slug key for tag. If left blank, one is created from name"
 msgstr ""
-"Yksisanainen tunniste tagille. Jos jätät tyhjäksi, sopiva luodaan tagin"
-" nimestä."
+"Yksisanainen tunniste tagille. Jos jätät tyhjäksi, sopiva luodaan tagin "
+"nimestä."
 
-#: django_colortag/models.py:19
+#: django_colortag_/models.py:25
 msgid "Describe the usage or meaning of this tag"
 msgstr "Kuvaile tagin käyttö tai merkitys."
 
-#: django_colortag/models.py:20
+#: django_colortag_/models.py:26
 msgid "Color that is used as background for this tag"
 msgstr "Tagin taustaväri"
 
+#: django_colortag_/widgets.py:162
+msgid "Match any (OR)"
+msgstr "Sisällä osa (TAI)"
+
+#: django_colortag_/widgets.py:163
+msgid "Match all (AND)"
+msgstr "Sisällä kaikki (JA)"

--- a/django_colortag/static/django_colortag.css
+++ b/django_colortag/static/django_colortag.css
@@ -20,6 +20,21 @@
 	color: #000;
 	background-color: #ddd !important;
 }
+.btn.colortag.mltsb-state-2,
+.label.colortag.mltsb-state-2 {
+	background-image: linear-gradient(
+		to right,
+		rgba(221, 221, 221, 0) 6px,
+		rgba(221, 221, 221, 0.75) 8px 29px,
+		rgba(221, 221, 221, 0) 31px
+	);
+}
+.btn.colortag:not(.mltsb-2-stage) > i {
+	padding-right: 6px;
+}
+.btn.colortag.mltsb-state-2 > i {
+	color: #000;
+}
 .btn.colortag:hover {
 	opacity: 0.6;
 }

--- a/django_colortag/static/django_colortag.js
+++ b/django_colortag/static/django_colortag.js
@@ -54,13 +54,11 @@ function django_colortag_label(colortag, options_) {
 }
 
 function django_colortag_choice() {
-	jQuery(this).replaceCheckboxesWithButtons({
+	jQuery(this).replaceInputsWithMultiStateButtons({
 		groupClass: 'colortag-container',
 		buttonClass: '',
-		onicon: 'check',
-		officon: 'unchecked',
 		nocolor: true,
-		buttonSetup: function(input, button, group) {
+		buttonSetup: function(input, button) {
 			button.css('backgroundColor', input.data('background'));
 		},
 	});

--- a/django_colortag/templates/django_colortag/widgets/colortag_andor.html
+++ b/django_colortag/templates/django_colortag/widgets/colortag_andor.html
@@ -1,0 +1,4 @@
+<label class="and-or-label">
+  {% include "django/forms/widgets/input.html" %}
+  {{ widget.label }}
+</label>

--- a/django_colortag/templates/django_colortag/widgets/colortag_multiwidget.html
+++ b/django_colortag/templates/django_colortag/widgets/colortag_multiwidget.html
@@ -1,0 +1,3 @@
+<div {% include "django/forms/widgets/attrs.html" %}>
+  {% include "django/forms/widgets/multiwidget.html" %}
+</div>

--- a/django_colortag/widgets.py
+++ b/django_colortag/widgets.py
@@ -2,6 +2,7 @@ from itertools import chain
 
 from django.forms import widgets
 from django.utils.encoding import force_text
+from django.utils.translation import ugettext_lazy as _
 
 
 def get_colortag_attrs(colortag, options):
@@ -34,16 +35,35 @@ def get_colortag_classes(colortag, options):
     return cls
 
 
-class ColortagSelectMultiple(widgets.CheckboxSelectMultiple):
-
-    option_inherits_attrs = False # option checkboxes need not inherit attributes from the list element
+class ColortagMixIn:
+    option_inherits_attrs = False
+    class_name = 'colortag'
 
     def __init__(self, attrs=None, choices=()):
         super().__init__(attrs=attrs, choices=choices)
         if 'class' in self.attrs:
-            self.attrs['class'] += ' colortag-choice'
+            self.attrs['class'] += ' ' + self.class_name
         else:
-            self.attrs['class'] = 'colortag-choice'
+            self.attrs['class'] = self.class_name
+
+
+class ColortagSelectMultiple(ColortagMixIn, widgets.CheckboxSelectMultiple):
+    class_name = 'colortag-choice'
+
+    def create_option(self, name, value, label, selected, index, subindex=None, attrs=None,
+            colortag_instance=None):
+        # colortag_instance is a new parameter that is not used in the super class method.
+        # The overridden optgroups method uses this method.
+        option = super().create_option(name, value, label, selected, index, subindex=subindex, attrs=attrs)
+        if colortag_instance is None:
+            return option
+        # Add custom attributes to the option (one checkbox) that are based on
+        # the corresponding ColorTag instance.
+        opts = { 'button': True }
+        attrs = option['attrs']
+        attrs.update(get_colortag_attrs(colortag_instance, opts))
+        attrs['data-class'] = ' '.join(get_colortag_classes(colortag_instance, opts))
+        return option
 
     def optgroups(self, name, value, attrs=None):
         """Return a list of optgroups for this widget."""
@@ -86,18 +106,83 @@ class ColortagSelectMultiple(widgets.CheckboxSelectMultiple):
                     subindex += 1
         return groups
 
-    def create_option(self, name, value, label, selected, index, subindex=None, attrs=None,
-            colortag_instance=None):
-        # colortag_instance is a new parameter that is not used in the super class method.
-        # The overridden optgroups method uses this method.
-        option = super().create_option(name, value, label, selected, index, subindex=subindex, attrs=attrs)
-        if colortag_instance is None:
-            return option
-        # Add custom attributes to the option (one checkbox) that are based on
-        # the corresponding ColorTag instance.
+
+class ColortagIncludeExcludeWidget(ColortagMixIn, widgets.Select):
+    class_name = 'colortag-inc-exc'
+
+    def __init__(self, attrs=None, tag=None):
+        assert tag, "The choice must be defined"
         opts = { 'button': True }
-        attrs = option['attrs']
-        attrs.update(get_colortag_attrs(colortag_instance, opts))
-        attrs['data-class'] = ' '.join(get_colortag_classes(colortag_instance, opts))
+        if attrs == None:
+            attrs = {}
+        attrs.update(get_colortag_attrs(tag, opts))
+        attrs['data-class'] = ' '.join(get_colortag_classes(tag, opts))
+        choices = [
+            ('', tag.name),
+            ('I' + str(tag.pk), "Include"),
+            ('E' + str(tag.pk), "Exclude"),
+        ]
+        self.__text = tag.name
+        super().__init__(attrs, choices)
+
+    def create_option(self, name, value, label, selected, index, subindex=None, attrs=None):
+        option = super().create_option(name, value, label, selected, index, subindex=subindex, attrs=attrs)
+        option['attrs']['data-text'] = self.__text
         return option
 
+
+class ColortagIEMultiWidget(widgets.MultiWidget):
+    template_name = "django_colortag/widgets/colortag_multiwidget.html"
+    class_name = 'colortag-ie-group'
+
+    def __init__(self, attrs=None, choices=None):
+        widgets = [ColortagIncludeExcludeWidget(attrs, c) for c in choices] if choices else []
+        super().__init__(widgets, attrs)
+        if 'class' in self.attrs:
+            self.attrs['class'] += ' ' + self.class_name
+        else:
+            self.attrs['class'] = self.class_name
+
+    def set_subwidgets(self, choices):
+        self.widgets = [ColortagIncludeExcludeWidget(tag=c) for c in choices]
+
+    def decompress(self, value):
+        if value == None:
+            return [None for w in self.widgets]
+        return value
+
+
+class AndOrWidget(widgets.CheckboxInput):
+    template_name = "django_colortag/widgets/colortag_andor.html"
+
+    def __init__(self, attrs=None, check_test=None, label=None):
+        self.label = label
+        if attrs == None:
+            attrs = {}
+        attrs.setdefault('data-off-text', _("Match any (OR)"))
+        attrs.setdefault('data-on-text', _("Match all (AND)"))
+        # TODO: generate a help text, use an info-circle and a tooltip to display
+        super().__init__(attrs, check_test)
+
+    def get_context(self, name, value, attrs):
+        context = super().get_context(name, value, attrs)
+        context['widget']['label'] = self.label
+        return context
+
+
+class ColortagIEAndOrWidget(widgets.MultiWidget):
+
+    def __init__(self, attrs=None, choices=None):
+        widgets = (
+            AndOrWidget(label="Feedbacks must have all selected tags"),
+            ColortagIEMultiWidget(attrs, choices)
+        )
+        super().__init__(widgets, attrs)
+
+    def set_subwidgets(self, choices):
+        self.widgets[1].set_subwidgets(choices)
+
+    def decompress(self, value):
+        if value == None:
+            return [None, None]
+        return value


### PR DESCRIPTION
Created include-exclude-filters, also has option of choosing whether
to combine includes with AND or OR.
CSS now supports three-state-buttons.