### PR TITLE
Construct tag widget names based on tag slugs instead of ordinal numbers

### DIFF
--- a/django_colortag/widgets.py
+++ b/django_colortag/widgets.py
@@ -145,7 +145,7 @@ class ColortagIEMultiWidget(widgets.MultiWidget):
 
     def set_subwidgets(self, choices):
         self.widgets = [ColortagIncludeExcludeWidget(tag=c) for c in choices]
-        self.widgets_names = ['_%s' % i for i in range(len(self.widgets))]
+        self.widgets_names = ['_%s' % choices[i].slug for i in range(len(self.widgets))]
 
     def decompress(self, value):
         if value == None:


### PR DESCRIPTION
# Description

**What?**

Widget names are now constructed according to tag slugs instead of ordinal numbers in ColortagIEMultiWidget. The widget names were previously "tags_1_{idx}". Now they are "tags_{slug}".

**Why?**

Since the widget names were previously based on index, the names may change if new tags are added or deleted. This pr makes the widget names unique and stable.

**How?**

Variable self.widgets_names adds the suffix "_{slug}". Method get_context adds the prefix "tags". The latter is quite a dirty solution, but it works and I have no idea where the method gets its name parameter "tags_1".

Fixes issue https://github.com/apluslms/mooc-jutut/issues/91.

# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Added feedback tags in Jutut. Filtered feedbacks by tags and checked that the search url changed according to the new widget names.

**Did you test the changes in**

- [ ] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
