### PR TITLE
Enable rendering of pinned colortags

### DIFF
--- a/django_colortag/models.py
+++ b/django_colortag/models.py
@@ -44,6 +44,10 @@ class ColorTag(models.Model):
     def html_label(self):
         return render_as_button(self, {'static': True})
 
+    @cached_property
+    def is_pinned(self):
+        return False
+
     def __str__(self):
         return 'ColorTag({!r}, {!r}, {!r})'.format(
             self.name, self.slug, self.description

--- a/django_colortag/static/django_colortag.css
+++ b/django_colortag/static/django_colortag.css
@@ -42,3 +42,17 @@
 .btn.colortag:hover {
 	opacity: 0.6;
 }
+
+.colortag.pinned:after {
+	position: relative;
+	top: 0px;
+	left: 4px;
+	display: inline-block;
+	font-family: 'Glyphicons Halflings';
+	font-style: normal;
+	font-weight: 400;
+	font-size: 0.7em;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	content: "\e146";
+}

--- a/django_colortag/widgets.py
+++ b/django_colortag/widgets.py
@@ -24,6 +24,8 @@ def get_colortag_attrs(colortag, options):
 def get_colortag_classes(colortag, options):
     cls = set(('colortag',))
     cls.add('colortag-dark' if colortag.font_white else 'colortag-light')
+    if colortag.is_pinned:
+        cls.add('pinned')
     if options.get('active'):
         cls.add('colortag-active')
     if options.get('button'):


### PR DESCRIPTION
# Description

**What?**

Add functionalities that allow subclasses to implement pinning. If a tag is pinned, display a pushpin icon behind the colortag.

**Why?**

So Jutut can enable pinning of feedback tags.

**How?**

Adding a cached property `is_pinned`, using that to determine if a colortag should have the "pinned" class, and if it does, use css `:after` to add a pushpin icon to the end of the colortag.

Required for [mooc-jutut issue #66](https://github.com/apluslms/mooc-jutut/issues/66)


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that pinned tags appear correctly (as do unpinned ones), and classes that inherit colortag but don't have the pinned functionality still work properly.

**Did you test the changes in**

- [ ] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
